### PR TITLE
PGN reading improvements

### DIFF
--- a/src/Game/Board.cpp
+++ b/src/Game/Board.cpp
@@ -457,7 +457,18 @@ int Board::castling_direction(Piece_Color player) const noexcept
 const Move& Board::interpret_move(const std::string& move_text) const
 {
     constexpr static auto end_marks = "+#?!";
-    const auto raw = [](const auto& text) { return text.substr(0, text.find_first_of(end_marks)); };
+    const auto raw = [](const auto& text)
+        {
+            const auto mark_location = text.find_first_of(end_marks);
+            if(mark_location >= text.size() - 1)
+            {
+                return text.substr(0, mark_location);
+            }
+            else
+            {
+                return text;
+            }
+        };
     const auto raw_move_text = raw(move_text);
     const auto move_iter = std::find_if(legal_moves().begin(), legal_moves().end(),
                                         [this, &raw_move_text, raw](auto move)

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -276,7 +276,7 @@ bool PGN::confirm_game_record(const std::string& file_name)
         {
             if(in_game)
             {
-                std::cout << "File ended in middle of game.\n";
+                std::cerr << "File ended in middle of game.\n";
             }
             else
             {

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -269,7 +269,6 @@ bool PGN::confirm_game_record(const std::string& file_name)
             board_before_last_move = Board();
             result = {};
             ++game_count;
-            std::cout << "Games checked: " << game_count << std::endl;
         }
 
         const auto next_character = char(input.get());

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -151,20 +151,9 @@ namespace
             }
 
             const auto rav_is_complete = (c == ')');
-            if(word.empty())
+            if(word.empty() || String::contains(word, "."))
             {
-                if(rav_is_complete)
-                {
-                    return true;
-                }
-                else
-                {
-                    continue;
-                }
-            }
-            else if(String::contains(word, "."))
-            {
-                // Move number, i.e., 1.
+                // Do nothing (is empty or is a move number: 1.)
             }
             else if(board.is_legal_move(word))
             {

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -161,7 +161,7 @@ namespace
             else
             {
                 const auto line_count = line_number(input, input_position);
-                std::cerr << "Unable to parse token '" << word << "' in RAV starting at line " << line_count << ".";
+                std::cerr << "Unable to parse token '" << word << "' in RAV starting at line " << line_count << ".\n";
                 return false;
             }
 

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -358,17 +358,6 @@ bool PGN::confirm_game_record(const std::string& file_name)
         const auto token = word;
         word.clear();
 
-        if(token.back() == '.')
-        {
-            move_number = String::split(token, ".")[0] + ". ";
-            continue;
-        }
-
-        if(board.whose_turn() == Piece_Color::BLACK)
-        {
-            move_number += "... ";
-        }
-
         if(std::find(valid_result_marks.begin(), valid_result_marks.end(), token) != valid_result_marks.end())
         {
             if(token != headers["Result"])
@@ -424,6 +413,17 @@ bool PGN::confirm_game_record(const std::string& file_name)
             result = {};
             ++game_count;
             continue;
+        }
+
+        if(std::isdigit(token.front()))
+        {
+            move_number = String::split(token, ".")[0] + ". ";
+            continue;
+        }
+
+        if(board.whose_turn() == Piece_Color::BLACK)
+        {
+            move_number += "... ";
         }
 
         if( ! board.is_legal_move(token))

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -426,40 +426,7 @@ bool PGN::confirm_game_record(const std::string& file_name)
             continue;
         }
 
-        try
-        {
-            const auto& move_to_play = board.interpret_move(token);
-            if( ! check_rule_result("Move: " + move_number + token + ")",
-                                    "capture",
-                                    String::contains(token, 'x'),
-                                    board.move_captures(move_to_play),
-                                    input))
-            {
-                return false;
-            }
-
-            board_before_last_move = board;
-            result = board.play_move(move_to_play);
-
-            if( ! check_rule_result("Move (" + move_number + token + ")",
-                                    "check",
-                                    String::contains("+#", token.back()),
-                                    board.king_is_in_check(),
-                                    input))
-            {
-                return false;
-            }
-
-            if( ! check_rule_result("Move (" + move_number + token + ")",
-                                    "checkmate",
-                                    token.back() == '#',
-                                    result.game_has_ended() && result.winner() != Winner_Color::NONE,
-                                    input))
-            {
-                return false;
-            }
-        }
-        catch(const Illegal_Move&)
+        if( ! board.is_legal_move(token))
         {
             const auto line_count = line_number(input, input.tellg());
             std::cerr << "Move (" << move_number << token << ") is illegal" << " (line: " << line_count << ").\n";
@@ -470,6 +437,37 @@ bool PGN::confirm_game_record(const std::string& file_name)
                 std::cerr << legal_move->algebraic(board) << " ";
             }
             std::cerr << '\n' << board.fen() << '\n';
+            return false;
+        }
+
+        const auto& move_to_play = board.interpret_move(token);
+        if( ! check_rule_result("Move: " + move_number + token + ")",
+                                "capture",
+                                String::contains(token, 'x'),
+                                board.move_captures(move_to_play),
+                                input))
+        {
+            return false;
+        }
+
+        board_before_last_move = board;
+        result = board.play_move(move_to_play);
+
+        if( ! check_rule_result("Move (" + move_number + token + ")",
+                                "check",
+                                String::contains("+#", token.back()),
+                                board.king_is_in_check(),
+                                input))
+        {
+            return false;
+        }
+
+        if( ! check_rule_result("Move (" + move_number + token + ")",
+                                "checkmate",
+                                token.back() == '#',
+                                result.game_has_ended() && result.winner() != Winner_Color::NONE,
+                                input))
+        {
             return false;
         }
     }

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -113,8 +113,6 @@ namespace
                 return false;
             }
 
-            const auto rav_is_complete = (c == ')');
-
             switch(c)
             {
                 case '(':
@@ -143,6 +141,7 @@ namespace
                     continue;
             }
 
+            const auto rav_is_complete = (c == ')');
             if(word.empty())
             {
                 if(rav_is_complete)

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -201,6 +201,13 @@ namespace
             return false;
         }
 
+        if(headers.count(tag_name) != 0)
+        {
+            const auto line_count = line_number(input, brace_position);
+            std::cerr << "Duplicate header tag name: " << tag_name << " (line: " << line_count << ")\n";
+            return false;
+        }
+
         std::string tag_value;
         std::getline(input, tag_value, '"');
         headers[tag_name] = String::remove_extra_whitespace(tag_value);

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -150,9 +150,9 @@ namespace
                     continue;
             }
 
-            if(word.empty() || String::contains(word, "."))
+            if(word.empty() || std::isdigit(word.front()))
             {
-                // Do nothing (is empty or is a move number: 1.)
+                // Do nothing (is empty or is a move number)
             }
             else if(board.is_legal_move(word))
             {

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -364,8 +364,6 @@ bool PGN::confirm_game_record(const std::string& file_name)
             continue;
         }
 
-        const auto token = word;
-        word.clear();
         if( ! in_game)
         {
             const auto result_value = headers["Result"];
@@ -403,6 +401,9 @@ bool PGN::confirm_game_record(const std::string& file_name)
         }
 
         in_game = true;
+
+        const auto token = word;
+        word.clear();
 
         if(token.back() == '.')
         {

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -97,18 +97,19 @@ namespace
     //! \param input A text input stream. The position within the input stream should be passed the opening parenthesis.
     bool confirm_rav(std::istream& input, Board board) noexcept
     {
+        const auto rav_start_position = input.tellg();
+        auto token_start = input.tellg();
         auto board_before_last_move = board;
         std::string word;
 
         while(true)
         {
-            const auto input_position = input.tellg();
             const auto c = char(input.get());
 
             if( ! input)
             {
-                const auto line_count = line_number(input, input_position);
-                std::cerr << "Reached end of input before end of RAV: line " << line_count << ".\n";
+                const auto line_count = line_number(input, rav_start_position);
+                std::cerr << "Reached end of input before end of RAV starting at line " << line_count << ".\n";
                 return false;
             }
 
@@ -134,6 +135,10 @@ namespace
                 case '\n':
                     break;
                 default:
+                    if(word.empty())
+                    {
+                        token_start = input.tellg();
+                    }
                     word.push_back(c);
                     continue;
             }
@@ -160,7 +165,7 @@ namespace
             }
             else
             {
-                const auto line_count = line_number(input, input_position);
+                const auto line_count = line_number(input, token_start);
                 std::cerr << "Unable to parse token '" << word << "' in RAV starting at line " << line_count << ".\n";
                 return false;
             }

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -150,7 +150,6 @@ namespace
                     continue;
             }
 
-            const auto rav_is_complete = (c == ')');
             if(word.empty() || String::contains(word, "."))
             {
                 // Do nothing (is empty or is a move number: 1.)
@@ -167,7 +166,7 @@ namespace
                 return false;
             }
 
-            if(rav_is_complete)
+            if(c == ')')
             {
                 return true;
             }

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -194,10 +194,10 @@ namespace
         std::string tag_name;
         std::getline(input, tag_name, '"');
         tag_name = String::trim_outer_whitespace(tag_name);
-        if(tag_name != String::remove_extra_whitespace(tag_name))
+        if(std::any_of(tag_name.begin(), tag_name.end(), String::isspace))
         {
             const auto line_count = line_number(input, brace_position);
-            std::cerr << "Header tag name cannot contain spaces (line: " << line_count << ")\n";
+            std::cerr << "Header tag name cannot contain spaces: " << tag_name << " (line: " << line_count << ")\n";
             return false;
         }
 

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -101,10 +101,12 @@ namespace
         auto token_start = input.tellg();
         auto board_before_last_move = board;
         std::string word;
+        char saved_character = 0;
 
         while(true)
         {
-            const auto c = char(input.get());
+            const auto c = saved_character ? saved_character : char(input.get());
+            saved_character = 0;
 
             if( ! input)
             {
@@ -116,9 +118,16 @@ namespace
             switch(c)
             {
                 case '(':
-                    if( ! confirm_rav(input, board_before_last_move))
+                    if(word.empty())
                     {
-                        return false;
+                        if( ! confirm_rav(input, board_before_last_move))
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        saved_character = c;
                     }
                     break;
                 case ';':

--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -231,54 +231,12 @@ bool PGN::confirm_game_record(const std::string& file_name)
     auto expect_fifty_move_draw = false;
     auto expect_threefold_draw = false;
     auto in_game = false;
-    auto finished_game = false;
     std::map<std::string, std::string> headers;
     Board board;
     Board board_before_last_move;
     Game_Result result;
     while(true)
     {
-        if(finished_game)
-        {
-            if( ! check_rule_result("Header",
-                                    "50-move draw",
-                                    expect_fifty_move_draw,
-                                    String::contains(result.ending_reason(), "50"),
-                                    input))
-            {
-                return false;
-            }
-
-            if( ! check_rule_result("Header",
-                                    "threefold draw",
-                                    expect_threefold_draw,
-                                    String::contains(result.ending_reason(), "fold"),
-                                    input))
-            {
-                return false;
-            }
-
-            if( ! check_rule_result("Header",
-                                    "checkmate",
-                                    expect_checkmate,
-                                    String::contains(result.ending_reason(), "mates"),
-                                    input))
-            {
-                return false;
-            }
-
-            expect_checkmate = true;
-            expect_fifty_move_draw = false;
-            expect_threefold_draw = false;
-            in_game = false;
-            finished_game = false;
-            headers.clear();
-            board = Board();
-            board_before_last_move = Board();
-            result = {};
-            ++game_count;
-        }
-
         const auto next_character = saved_character ? saved_character : char(input.get());
         saved_character = 0;
         if( ! input && word.empty())
@@ -429,7 +387,42 @@ bool PGN::confirm_game_record(const std::string& file_name)
                 return false;
             }
 
-            finished_game = true;
+            if( ! check_rule_result("Header",
+                                    "50-move draw",
+                                    expect_fifty_move_draw,
+                                    String::contains(result.ending_reason(), "50"),
+                                    input))
+            {
+                return false;
+            }
+
+            if( ! check_rule_result("Header",
+                                    "threefold draw",
+                                    expect_threefold_draw,
+                                    String::contains(result.ending_reason(), "fold"),
+                                    input))
+            {
+                return false;
+            }
+
+            if( ! check_rule_result("Header",
+                                    "checkmate",
+                                    expect_checkmate,
+                                    String::contains(result.ending_reason(), "mates"),
+                                    input))
+            {
+                return false;
+            }
+
+            expect_checkmate = true;
+            expect_fifty_move_draw = false;
+            expect_threefold_draw = false;
+            in_game = false;
+            headers.clear();
+            board = Board();
+            board_before_last_move = Board();
+            result = {};
+            ++game_count;
             continue;
         }
 


### PR DESCRIPTION
Various PGN reading/confirming improvements:

- Make fewer assumptions on the form of PGN files by processing character-by-character.
- Instead of skipping RAVs, confirm that they have legal moves. Fixes #149