### PR TITLE
Simpler PGN reading

### DIFF
--- a/src/Game/PGN.cpp
+++ b/src/Game/PGN.cpp
@@ -12,30 +12,29 @@
 #include <fstream>
 #include <string>
 #include <map>
+#include <sstream>
 
 namespace
 {
     //! Print the line number of the input stream at the current position.
     int line_number(std::istream& input, std::streampos error_position) noexcept;
 
-    bool check_rule_result(const std::string& rule_source,
+    void check_rule_result(const std::string& rule_source,
                            const std::string& rule_name,
                            const bool expected_ruling,
                            const bool actual_ruling,
-                           std::istream& input) noexcept
+                           std::istream& input)
     {
-        const auto pass = expected_ruling == actual_ruling;
-        if( ! pass)
+        if(expected_ruling != actual_ruling)
         {
             const auto line_count = line_number(input, input.tellg());
-            std::cerr << rule_source << " indicates "
-                << (expected_ruling ? "" : "no ")
-                << rule_name << ", but last move did "
-                << (actual_ruling ? "" : "not ")
-                << "trigger rule (line: " << line_count << ").\n";
+            throw PGN_Error(std::format("{} indicates {}{}, but last move did {}trigger rule (line: {}).",
+                                        rule_source,
+                                        expected_ruling ? "" : "no ",
+                                        rule_name,
+                                        actual_ruling ? "" : "not ",
+                                        line_count));
         }
-
-        return pass;
     }
 
     //! \brief Skip passed the given character
@@ -75,27 +74,24 @@ namespace
         return line_count;
     }
 
-    //! \brief Skip to the end of the current curly-braced comment. Returns true if successful, and false if the end of the input stream is reached.
+    //! \brief Skip to the end of the current curly-braced comment. Throws an exception if the end of the input stream is reached.
     //! 
     //! \param input A text input stream. The position within the input stream should be passed the opening curly brace.
-    bool skip_braced_comment(std::istream& input) noexcept
+    void skip_braced_comment(std::istream& input)
     {
         const auto stream_position = input.tellg();
         skip_passed_character(input, '}');
         if( ! input)
         {
             const auto line_count = line_number(input, stream_position);
-            std::cerr << "Reached end of input before closing curly brace: line " << line_count << ".\n";
-            return false;
+            throw PGN_Error(std::format("Reached end of input before closing curly brace: line {}.", line_count));
         }
-
-        return true;
     }
 
-    //! \brief Skip to the end of the current RAV section. Returns true if successful, and false if the end of the input stream is reached.
+    //! \brief Skip to the end of the current RAV section. Throws an exception if the end of the input stream is reached.
     //! 
     //! \param input A text input stream. The position within the input stream should be passed the opening parenthesis.
-    bool confirm_rav(std::istream& input, Board board) noexcept
+    void confirm_rav(std::istream& input, Board board)
     {
         const auto rav_start_position = input.tellg();
         auto token_start = input.tellg();
@@ -111,8 +107,7 @@ namespace
             if( ! input)
             {
                 const auto line_count = line_number(input, rav_start_position);
-                std::cerr << "Reached end of input before end of RAV starting at line " << line_count << ".\n";
-                return false;
+                throw PGN_Error(std::format("Reached end of input before end of RAV starting at line {}.", line_count));
             }
 
             switch(c)
@@ -120,10 +115,7 @@ namespace
                 case '(':
                     if(word.empty())
                     {
-                        if( ! confirm_rav(input, board_before_last_move))
-                        {
-                            return false;
-                        }
+                        confirm_rav(input, board_before_last_move);
                     }
                     else
                     {
@@ -176,20 +168,19 @@ namespace
             else
             {
                 const auto line_count = line_number(input, token_start);
-                std::cerr << "Unable to parse token '" << word << "' in RAV starting at line " << line_count << ".\n";
-                return false;
+                throw PGN_Error(std::format("Unable to parse token '{}' in RAV starting at line {}.", word, line_count));
             }
 
             if(c == ')')
             {
-                return true;
+                return;
             }
 
             word.clear();
         }
     }
 
-    bool add_header_data(std::ifstream& input, std::map<std::string, std::string>& headers) noexcept
+    void add_header_data(std::ifstream& input, std::map<std::string, std::string>& headers)
     {
         const auto brace_position = input.tellg();
 
@@ -199,15 +190,13 @@ namespace
         if(std::ranges::any_of(tag_name, String::isspace))
         {
             const auto line_count = line_number(input, brace_position);
-            std::cerr << "Header tag name cannot contain spaces: " << tag_name << " (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Header tag name cannot contain spaces: {} (line: {})", tag_name, line_count));
         }
 
         if(headers.count(tag_name) != 0)
         {
             const auto line_count = line_number(input, brace_position);
-            std::cerr << "Duplicate header tag name: " << tag_name << " (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Duplicate header tag name: {} (line: {})", tag_name, line_count));
         }
 
         std::string tag_value;
@@ -218,15 +207,12 @@ namespace
         if( ! input)
         {
             const auto line_count = line_number(input, brace_position);
-            std::cerr << "Malformed header tag (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Malformed header tag (line: {})", line_count));
         }
-
-        return true;
     }
 }
 
-bool PGN::confirm_game_record(const std::string& file_name)
+void PGN::confirm_game_record(const std::string& file_name)
 {
     auto input = std::ifstream(file_name);
     if( ! input)
@@ -257,14 +243,13 @@ bool PGN::confirm_game_record(const std::string& file_name)
         {
             if(in_game)
             {
-                std::cerr << "File ended in middle of game.\n";
+                throw PGN_Error("File ended in middle of game.");
             }
             else
             {
                 std::cout << "Found " << game_count << " " << (game_count == 1 ? "game" : "games") << ".\n";
+                return;
             }
-
-            return ! in_game;
         }
 
         if(std::isspace(next_character))
@@ -285,10 +270,7 @@ bool PGN::confirm_game_record(const std::string& file_name)
         {
             if(word.empty())
             {
-                if( ! skip_braced_comment(input))
-                {
-                    return false;
-                }
+                skip_braced_comment(input);
             }
             else
             {
@@ -298,17 +280,13 @@ bool PGN::confirm_game_record(const std::string& file_name)
         else if(next_character == '}')
         {
             const auto line_count = line_number(input, input.tellg());
-            std::cerr << "Found closing curly brace before opener (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Found closing curly brace before opener (line: {}).", line_count));
         }
         else if(next_character == '(')
         {
             if(word.empty())
             {
-                if( ! confirm_rav(input, board_before_last_move))
-                {
-                    return false;
-                }
+                confirm_rav(input, board_before_last_move);
             }
             else
             {
@@ -318,21 +296,16 @@ bool PGN::confirm_game_record(const std::string& file_name)
         else if(next_character == ')')
         {
             const auto line_count = line_number(input, input.tellg());
-            std::cerr << "Found closing RAV parentheses before opener (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Found closing RAV parentheses before opener (line: {})", line_count));
         }
         else if(in_game && next_character == '[')
         {
             const auto line_count = line_number(input, input.tellg());
-            std::cerr << "Found header line in the middle of another game (line: " << line_count << ")\n";
-            return false;
+            throw PGN_Error(std::format("Found header line in the middle of another game (line: {})", line_count));
         }
         else if(next_character == '[')
         {
-            if( ! add_header_data(input, headers))
-            {
-                return false;
-            }
+            add_header_data(input, headers);
         }
         else if(input)
         {
@@ -351,8 +324,7 @@ bool PGN::confirm_game_record(const std::string& file_name)
             if(std::ranges::find(valid_result_marks, result_value) == valid_result_marks.end())
             {
                 const auto line_count = line_number(input, input.tellg());
-                std::cerr << "Malformed Result tag: " << result_value << " (headers end at line: " << line_count << ")\n";
-                return false;
+                throw PGN_Error(std::format("Malformed Result tag: {} (headers end at line: {})", result_value, line_count));
             }
 
             if(result_value == "1/2-1/2" || result_value == "*")
@@ -391,45 +363,34 @@ bool PGN::confirm_game_record(const std::string& file_name)
             if(token != headers["Result"])
             {
                 const auto line_count = line_number(input, input.tellg());
-                std::cerr << "Final result mark (" << token << ") does not match game result. (line: " << line_count << ")\n";
-                return false;
+                throw PGN_Error(std::format("Final result mark ({}) does not match game result. (line: {})", token, line_count));
             }
 
             const auto final_board_result = result.game_ending_annotation();
             if(token != final_board_result)
             {
                 const auto line_count = line_number(input, input.tellg());
-                std::cerr << "Last move result (" << final_board_result << ") on line " << line_count
-                          << " does not match the game-ending tag (" << token << ").\n";
-                return false;
+                throw PGN_Error(std::format("Last move result ({}) on line {} does not match the game-ending tag ({}).",
+                                            final_board_result, line_count, token));
             }
 
-            if( ! check_rule_result("Header",
-                                    "50-move draw",
-                                    expect_fifty_move_draw,
-                                    String::contains(result.ending_reason(), "50"),
-                                    input))
-            {
-                return false;
-            }
+            check_rule_result("Header",
+                              "50-move draw",
+                              expect_fifty_move_draw,
+                              String::contains(result.ending_reason(), "50"),
+                              input);
 
-            if( ! check_rule_result("Header",
-                                    "threefold draw",
-                                    expect_threefold_draw,
-                                    String::contains(result.ending_reason(), "fold"),
-                                    input))
-            {
-                return false;
-            }
+            check_rule_result("Header",
+                              "threefold draw",
+                              expect_threefold_draw,
+                              String::contains(result.ending_reason(), "fold"),
+                              input);
 
-            if( ! check_rule_result("Header",
-                                    "checkmate",
-                                    expect_checkmate,
-                                    String::contains(result.ending_reason(), "mates"),
-                                    input))
-            {
-                return false;
-            }
+            check_rule_result("Header",
+                              "checkmate",
+                              expect_checkmate,
+                              String::contains(result.ending_reason(), "mates"),
+                              input);
 
             expect_checkmate = true;
             expect_fifty_move_draw = false;
@@ -457,46 +418,38 @@ bool PGN::confirm_game_record(const std::string& file_name)
         if( ! board.is_legal_move(token))
         {
             const auto line_count = line_number(input, input.tellg());
-            std::cerr << "Move (" << move_number << token << ") is illegal" << " (line: " << line_count << ").\n";
-            board.cli_print(std::cerr);
-            std::cerr << "\nLegal moves: ";
+            auto message = std::ostringstream();
+            message << "Move (" << move_number << token << ") is illegal" << " (line: " << line_count << ").\n";
+            board.cli_print(message);
+            message << "\nLegal moves: ";
             for(const auto legal_move : board.legal_moves())
             {
-                std::cerr << legal_move->algebraic(board) << " ";
+                message << legal_move->algebraic(board) << " ";
             }
-            std::cerr << '\n' << board.fen() << '\n';
-            return false;
+            message << '\n' << board.fen() << '\n';
+            throw PGN_Error(message.str());
         }
 
         const auto& move_to_play = board.interpret_move(token);
-        if( ! check_rule_result("Move: " + move_number + token + ")",
-                                "capture",
-                                String::contains(token, 'x'),
-                                board.move_captures(move_to_play),
-                                input))
-        {
-            return false;
-        }
+        check_rule_result("Move: " + move_number + token + ")",
+                          "capture",
+                          String::contains(token, 'x'),
+                          board.move_captures(move_to_play),
+                          input);
 
         board_before_last_move = board;
         result = board.play_move(move_to_play);
 
-        if( ! check_rule_result("Move (" + move_number + token + ")",
-                                "check",
-                                String::contains("+#", token.back()),
-                                board.king_is_in_check(),
-                                input))
-        {
-            return false;
-        }
+        check_rule_result("Move (" + move_number + token + ")",
+                          "check",
+                          String::contains("+#", token.back()),
+                          board.king_is_in_check(),
+                          input);
 
-        if( ! check_rule_result("Move (" + move_number + token + ")",
-                                "checkmate",
-                                token.back() == '#',
-                                result.game_has_ended() && result.winner() != Winner_Color::NONE,
-                                input))
-        {
-            return false;
-        }
+        check_rule_result("Move (" + move_number + token + ")",
+                          "checkmate",
+                          token.back() == '#',
+                          result.game_has_ended() && result.winner() != Winner_Color::NONE,
+                          input);
     }
 }

--- a/src/Game/PGN.h
+++ b/src/Game/PGN.h
@@ -7,7 +7,10 @@ namespace PGN
     //! \brief Confirm that all moves in a PGN game record are legal moves.
     //!
     //! \param file_name The name of the file with the PGN game records. All games will be examined.
-    bool confirm_game_record(const std::string& file_name);
+    //! 
+    //! If there is an error in a game record, an exception will be thrown. Otherwise, the number of
+    //! games read will be printed to the console.
+    void confirm_game_record(const std::string& file_name);
 
     //! \brief Format and print a header line for a PGN game.
     //! 

--- a/src/Utility/Exceptions.h
+++ b/src/Utility/Exceptions.h
@@ -41,4 +41,10 @@ class Illegal_Move : public std::runtime_error
     using std::runtime_error::runtime_error;
 };
 
+//! \brief An exception thrown when an error in a PGN text is found.
+class PGN_Error : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
 #endif // EXCEPTIONS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
         else if(option == "-confirm")
         {
             Main_Tools::argument_assert( ! parameters.empty(), "Provide a file containing games to confirm they have all legal moves.");
-            return PGN::confirm_game_record(parameters[0]) ? EXIT_SUCCESS : EXIT_FAILURE;
+            PGN::confirm_game_record(parameters[0]);
         }
         else if(option == "-test")
         {

--- a/testing/chess_engine_fight.py
+++ b/testing/chess_engine_fight.py
@@ -34,7 +34,7 @@ while True:
         print(out.stderr)
         break
 
-    result = subprocess.run([checker, '-confirm', game_file])
+    result = subprocess.run([checker, '-confirm', game_file], stdout=subprocess.DEVNULL)
     if result.returncode != 0:
         print('Found discrepancy. See ' + game_file)
         print('generator = ' + generator)


### PR DESCRIPTION
Replace functions that return bool with ones that throw an exception on encountering errors. This simplifies the logic and reduces the number of return statements.

Fixes #152